### PR TITLE
added credit to marvel and fixed mixed content bug

### DIFF
--- a/assets/js/character.js
+++ b/assets/js/character.js
@@ -5,18 +5,19 @@ function fetching() {
     var privateKey = '5d96d5ad0d54441e8920c0c482bc142e3efd0013';
     var ts = 1;
     var hash = hashing(ts, publicKey, privateKey);
-    var url = `http://gateway.marvel.com/v1/public/characters?ts=${ts}&apikey=${publicKey}&hash=${hash}&name=${charId}`;
+    var url = `https://gateway.marvel.com/v1/public/characters?ts=${ts}&apikey=${publicKey}&hash=${hash}&name=${charId}`;
     fetch(url)
     .then(function (response) {
         return response.json()
     })
     .then(function (data) {
+        console.log (data)
         const charPath = data.data.results[0].thumbnail.path 
         const charImg = (charPath + "/portrait_incredible.jpg")
-        console.log (charImg)
         document.getElementById('name').textContent = data.data.results[0].name
       document.getElementById('description').textContent = data.data.results[0].description;
       document.getElementById("charImg").src = charImg; 
+      document.getElementById("marvelcredit").textContent = "Made with Love by Marvel Fans (Abel, Yuliia, Michael) " +data.attributionText;
     })
 }
 

--- a/character.html
+++ b/character.html
@@ -77,8 +77,7 @@
       </div>
     </div>
     <footer id="footer">
-      <h4 class="white-text brown darken-2">
-       Made with Love by Marvel Fans (Abel, Yuliia, Michael)
+      <h4 id="marvelcredit" class="white-text brown darken-2">
       </h4>
     </footer>
     


### PR DESCRIPTION
On the main deployed website there is a bug that happens when you search up a character which doesn't allow the character information to display. This should fix that and will also add copyright for the marvel website.